### PR TITLE
fix: Add bandit scan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,9 @@ import-order-style = "pycharm"
 [tool.mypy]
 files = "src"
 disable_error_code = "import-untyped"
+
+[tool.bandit]
+exclude_dirs = [
+    "tests",
+    "docs"
+]

--- a/src/xmlcli_mod/xmlcli.py
+++ b/src/xmlcli_mod/xmlcli.py
@@ -21,8 +21,7 @@
 
 import logging
 from pathlib import Path
-from xml.etree.ElementTree import Element
-from xml.etree.ElementTree import ElementTree
+from xml.etree.ElementTree import Element, ElementTree  # nosec B405, not used for parsing xml data
 
 import defusedxml.ElementTree as ET
 from xmlcli_mod import xmlclilib


### PR DESCRIPTION
The only bandit issue found was importing Element and ElementTree from the standard xml module, but these are not used to parse xml data, the data is parsed with defusedxml and then it is converted to an ElementTree